### PR TITLE
Improvements to timeline display

### DIFF
--- a/src/components/ProgressTimeline.vue
+++ b/src/components/ProgressTimeline.vue
@@ -34,12 +34,14 @@ export default {
   computed: {
   },
   mounted () {
-    this.roundTickWidths();
-    window.addEventListener('resize', this.roundTickWidths);
+    this.roundTickWidths()
+    window.addEventListener('resize', this.roundTickWidths)
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.roundTickWidths)
   },
   methods: {
     roundTickWidths() {
-      console.log("resizing")
       this.$refs.timelineElement.style.removeProperty('--tick-width')
       const computedWidth = parseInt(window.getComputedStyle(document.querySelector('#progress-timeline .chapter')).getPropertyValue('width'))
       this.$refs.timelineElement.style.setProperty('--tick-width',Math.round(computedWidth) + "px")


### PR DESCRIPTION
Not sure if you noticed that the ticks looked wonky before, like they weren't all the same size. It was a subpixel rendering issue, requiring some JS to fix while keeping it responsive